### PR TITLE
Add MikeSmith as (other) W3C signing member

### DIFF
--- a/steering-committee/membership-expectations.md
+++ b/steering-committee/membership-expectations.md
@@ -44,3 +44,4 @@ In support of these expectations,
 - Chris Mills (Mozilla)
 - Jory Burson (Open Web Docs)
 - Lola Odelola (Samsung)
+- Michael[tm] Smith (W3C)


### PR DESCRIPTION
@dontcallmedom would like me to act as his alternate for representing the W3C in steering committee meetings

